### PR TITLE
Update Dynamic framework usage for swift 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ ReactorKit via Carthage
 ```ruby
 binary "https://github.com/kawoou/ReactorKit-Carthage/raw/master/ReactorKit"
 
-binary "https://github.com/kawoou/ReactorKit-Carthage/raw/master/ReactorKit" ~> 1.2.0   # Swift 4.2
-binary "https://github.com/kawoou/ReactorKit-Carthage/raw/master/ReactorKit" ~> 1.2.1   # Swift 4.2.1
+binary "https://github.com/kawoou/ReactorKit-Carthage/raw/master/ReactorKit" == 1.2.0   # Swift 4.2
+binary "https://github.com/kawoou/ReactorKit-Carthage/raw/master/ReactorKit" == 1.2.1   # Swift 4.2.1
 ```
 
 


### PR DESCRIPTION
> Dependency Version: This is how you tell Carthage which version of a dependency you’d like to use. There are a number of options at your disposal, depending on how specific you want to be:
`==` 1.0 means “Use exactly version 1.0”
`>=` 1.0 means “Use version 1.0 or higher”
`~>` 1.0 means “Use any version that’s compatible with 1.0″, essentially meaning any version up until the next major release.
